### PR TITLE
Allow using `rand.Source` to initialise

### DIFF
--- a/loremipsum.go
+++ b/loremipsum.go
@@ -21,8 +21,14 @@ func New() *LoremIpsum {
 
 // New returns new instance of LoremIpsum with PRNG seeded with the parameter
 func NewWithSeed(seed int64) *LoremIpsum {
+	return NewWithSource(rand.NewSource(seed))
+}
+
+// NewWithSource returns new instance of LoremIpsum that uses random values
+// from source to generate words.
+func NewWithSource(source rand.Source) *LoremIpsum {
 	li := new(LoremIpsum)
-	li.rng = rand.New(rand.NewSource(seed))
+	li.rng = rand.New(source)
 	li.first = true
 	li.idx = 0
 	li.shuffle()

--- a/loremipsum_test.go
+++ b/loremipsum_test.go
@@ -2,6 +2,7 @@ package loremipsum
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -72,9 +73,21 @@ func TestLoremIpsum_Paragraphs(t *testing.T) {
 }
 
 func TestLoremIpsum_NewWithSeed(t *testing.T) {
+	testSeed(t,
+		NewWithSeed(1),
+		NewWithSeed(1),
+	)
+}
+
+func TestLoremIpsum_NewWithSource(t *testing.T) {
+	testSeed(t,
+		NewWithSource(rand.New(rand.NewSource(1))),
+		NewWithSource(rand.New(rand.NewSource(1))),
+	)
+}
+
+func testSeed(t *testing.T, liSeeded1, liSeeded2 *LoremIpsum) {
 	liRandom := New()
-	liSeeded1 := NewWithSeed(1)
-	liSeeded2 := NewWithSeed(1)
 
 	var liRandomList []string
 	var liSeeded1List []string
@@ -95,5 +108,4 @@ func TestLoremIpsum_NewWithSeed(t *testing.T) {
 			assert.NotEqual(t, liSeeded1List[i], liSeeded1List[i+1])
 		}
 	}
-
 }


### PR DESCRIPTION
It is currently possible to create a consistent generator by using
`NewWithSeed` which accepts an integer seed value.

Often times we already have a seed source but this package doesn't allow
to make use of it.

So this change adds another way to create a generator that accepts a
more generic seed source.