### PR TITLE
Fix successive calls to Sentence() returns very similar sentences

### DIFF
--- a/loremipsum.go
+++ b/loremipsum.go
@@ -52,6 +52,7 @@ func (li *LoremIpsum) Words(count int) string {
 
 // Sentence returns full sentence of lorem ipsum
 func (li *LoremIpsum) Sentence() string {
+	defer li.shuffle()
 	for {
 		l := int(li.gauss(24.46, 5.08))
 		if l > 0 {
@@ -66,7 +67,6 @@ func (li *LoremIpsum) SentenceList(count int) []string {
 	sentences := make([]string, count)
 	for idx := range sentences {
 		sentences[idx] = li.Sentence()
-		li.shuffle()
 	}
 	return sentences
 }


### PR DESCRIPTION
By calling `li.shuffle()` at the end of `Sentence()` instead of in `SentenceList()`, successive calls to `Sentence()` actually return very different sentences instead of small variations of the same sentence.

Closes: #9
